### PR TITLE
Unittest

### DIFF
--- a/.github/workflows/repo-test.yml
+++ b/.github/workflows/repo-test.yml
@@ -1,5 +1,6 @@
 name: Testing OFMF
 on:
+  workflow_dispatch:
   push:
     branches: master
   pull_request:

--- a/setup.sh
+++ b/setup.sh
@@ -139,6 +139,7 @@ cp -r -f "$BASE_DIR"/emulator.py "$WORK_DIR"/
 cp -r -f "$BASE_DIR"/ofmf-main.py "$WORK_DIR"/
 cp -r -f "$BASE_DIR"/certificate_config.cnf "$WORK_DIR"/
 cp -r -f "$BASE_DIR"/v3.ext "$WORK_DIR"/
+cp -r -f "$BASE_DIR"/tests "$WORK_DIR"/
 
 # generating server key
 echo "Generating private key"

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,69 +1,34 @@
-import json
-import pprint
-import requests
 import test_templates
-import sys
+import unittest
+from api_emulator.resource_manager import ResourceManager
+import g
 
-def send_post(url, payload):
-    headers = {'Content-type':'application/json', 'Accept':'text/plain'}
-    resp = requests.post (url, data = json.dumps(payload), headers = headers)
+REST_BASE = '/redfish/v1'
+g.rest_base = REST_BASE
 
-    return resp.status_code
+class TestOFMF(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        global resource_manager
+        global REST_BASE
+        global TRAYS
+        global SPEC
+        resource_manager = ResourceManager(None, None, None, "Disable", None)
+        g.app.testing = True
+        cls.client = g.app.test_client()
 
-def send_get(url):
-    resp = requests.get(url)
+    def test_create_computer_system(self):
+        system_url = f"{REST_BASE}/Systems"
+        response = self.client.post(system_url, json=test_templates.test_system)
+        status_code = response.status_code
+        self.assertEqual(status_code, 200)
 
-    return resp.status_code, resp.json()
-
-def send_delete(url):
-    resp = requests.delete(url)
-
-    return resp.status_code
-
-def test_create_chassis(url):
-    chassis_url = f"{url}/Chassis"
-    ret_code = send_post(chassis_url, test_templates.test_chassis)
-
-    if ret_code == 200:
-        return True
-    else:
-        return False
-
-def test_create_computer_system(url):
-    # I am assuming we have already created the target Chassis
-    system_url = f"{url}/Systems"
-    ret_code = send_post(system_url, test_templates.test_system)
-
-    if ret_code == 200:
-        return True
-    else:
-        return False
-
-
-def test_create_computer_system_duplicate_id():
-    # To Be Implemented
-    pass
-
-
-def main():
-    url = "http://localhost:5000/redfish/v1"
-
-    print("##### Starting test Suite  #####")
-    print()
-    print ("Testing creating a Chassis...")
-    if test_create_chassis(url):
-        print ("PASSED")
-    else:
-        print ("FAILED")
-        sys.exit(1)
-
-    print("Testing creating a ComputerSystem...")
-    if test_create_computer_system(url):
-        print ("PASSED")
-    else:
-        print ("FAILED")
-        sys.exit(1)
-
+    def test_create_chassis(self):
+        chassis_url = f"{REST_BASE}/Chassis"
+        response = self.client.post(chassis_url, json=test_templates.test_chassis)
+        status_code = response.status_code
+        self.assertEqual(status_code, 200)
 
 if __name__ == '__main__':
-    main()
+    unittest.main()
+#     main()

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,42 +1,10 @@
 #!/bin/bash
-TIMEOUT=30
-
-wait_ofmf () {
-    NOW=0
-    ELAPSED=0
-    START=$(date +"%s")
-    while [ $ELAPSED -lt $TIMEOUT ]
-    do
-        curl http://localhost:5000/redfish/v1 > /dev/null 2>&1
-        if [ $? -eq 0 ]
-        then
-            return 0
-        fi
-        # No need to go crazy here, let's sleep for a while
-        sleep 1
-        NOW=$(date +"%s")
-        ELAPSED=$((${NOW} - ${START}))
-    done
-
-    return 1
-}
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "Script dir: $SCRIPT_DIR"
 
 ${SCRIPT_DIR}/../setup.sh -w ./emul -n
 
-cp ${SCRIPT_DIR}/emulator-config-http.json ${SCRIPT_DIR}/../emul/emulator-config.json
 cd ${SCRIPT_DIR}/../emul
-./venv/bin/python emulator.py &
-cd -
 
-# wait for the OFMF service to be up of fail after TIMEOUT seconds
-wait_ofmf
-if [ $? -eq 1 ]
-then
-    echo "Timing out, the OFMF failed to start"
-    exit 1
-fi
-
-python ${SCRIPT_DIR}/test.py
+python -m unittest discover -s tests

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -7,4 +7,6 @@ ${SCRIPT_DIR}/../setup.sh -w ./emul -n
 
 cd ${SCRIPT_DIR}/../emul
 
+source ./venv/bin/activate
+
 python -m unittest discover -s tests


### PR DESCRIPTION
This PR replaces the existing testing framework with unittest. This is an improvement as it does not require for the whole framework to be executed and tested externally via a different process. 

The new framework relies on the flask_restful `test_client` for issuing GET/POST requests towards the RedFish API.