### PR TITLE
Fixed path creation in utils.py

### DIFF
--- a/api_emulator/utils.py
+++ b/api_emulator/utils.py
@@ -160,7 +160,9 @@ def update_collections_parent_json(path, type, link):
         json.dump(data, file_json, indent=4, sort_keys=True)
 
 def create_path(*args):
-    trimmed = [str(arg).strip('/') for arg in args]
+    # we want to keep the leading '/' should the root be passed as an absolute path
+    trimmed = [args[0].rstrip('/')]
+    trimmed.extend([str(arg).strip('/') for arg in args[1:]])
     return os.path.join(*trimmed)
 
     # HTTP GET


### PR DESCRIPTION
Small fix in utils.py that prevented the emulator to work if the root path is an absolute path (i.e., it starts with '/')